### PR TITLE
[ADD]: 버튼 컴포넌트 추가

### DIFF
--- a/front/src/components/Common/Button/Button.tsx
+++ b/front/src/components/Common/Button/Button.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode | string;
+  bgColor?: string;
+  fontColor?: string;
+  fullWidth?: boolean;
+}
+
+function Button({ children, ...props }: ButtonProps) {
+  return <StyledButton {...props}>{children}</StyledButton>;
+}
+
+const colorStyle = css<ButtonProps>`
+  ${({ bgColor, fontColor }) => css`
+    color: ${fontColor || '#ffffff'};
+    background-color: ${bgColor || '#3b5bdb'};
+    &:hover {
+      background-color: ${bgColor || '#526bd1'};
+    }
+  `}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      background-color: rgba(82, 88, 102, 0.2);
+      color: rgba(82, 88, 102, 0.3215686274509804);
+      cursor: default;
+    `}
+`;
+
+const StyledButton = styled.button<ButtonProps>`
+  ${({ fullWidth }) => fullWidth && 'width: 100%;'}
+  height: 2.5rem;
+  padding: 0 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  ${colorStyle}
+`;
+
+export default React.memo(Button);

--- a/front/src/components/Common/Button/index.ts
+++ b/front/src/components/Common/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button';


### PR DESCRIPTION
## 개요 🪧

버튼 컴포넌트 추가
 
## 작업 내용 📄
- bgColor(백그라운드 컬러), fontColor, fullWidth 프롭스로 스타일 설정 가능
- 리액트 기본 버튼 속성 타입을 상속받아 일반 버튼 태그처럼 사용 가능
> 아직 컬러 팔레트를 정하지 않아서 임의로 색상 설정. 컬러 팔레트 추가되고 테마 추가되면 수정 예정

## 변경 로직 ⚙️
## 스크린샷 📸
![스크린샷 2021-04-30 오후 10 58 43](https://user-images.githubusercontent.com/36879690/116705617-b00bfa00-aa07-11eb-8b6a-5e4011d4214a.png)
![스크린샷 2021-04-30 오후 10 58 49](https://user-images.githubusercontent.com/36879690/116705650-ba2df880-aa07-11eb-92e5-b6e7f1f17b39.png)


