### PR TITLE
/article 응답 데이터 페이지 정보 추가

### DIFF
--- a/api_server/src/repository/ArticleRepository.ts
+++ b/api_server/src/repository/ArticleRepository.ts
@@ -1,21 +1,26 @@
-import ArticleModel from '../model/Article';
+import { PaginateOptions, PaginateResult } from 'mongoose';
+import Article, {ArticleModel} from '../model/Article';
 
 const RssFeedRepository = class {
-  private articleModel;
-  private paginateOptions = {
+  private article;
+  private paginateOptions: PaginateOptions = {
     limit: 20,
+    sort: {
+      insertDate: -1
+    }
   };
-  constructor(articleModel: typeof ArticleModel) {
-    this.articleModel = articleModel;
+  constructor(article: typeof Article) {
+    this.article = article;
   }
   async pagenateFeed(
     page: number
   ): Promise<{
     code: number;
-    data: any;
+    data?: PaginateResult<ArticleModel>;
+    message?: string;
   }> {
     try {
-      const result = await this.articleModel.paginate(
+      const result = await this.article.paginate(
         {},
         { ...this.paginateOptions, page }
       );
@@ -23,15 +28,16 @@ const RssFeedRepository = class {
       return {
         code: 200,
         data: result,
+        message: '정상적으로 처리되었습니다.'
       };
     } catch (e) {
       console.log(e);
       return {
         code: 503,
-        data: '에러가 발생했습니다.',
+        message: '에러가 발생했습니다.',
       };
     }
   }
 };
 
-export default new RssFeedRepository(ArticleModel);
+export default new RssFeedRepository(Article);

--- a/api_server/src/router/articleRouter.ts
+++ b/api_server/src/router/articleRouter.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 import RssFeedRepository from '../repository/ArticleRepository';
+import { PaginateResult } from 'mongoose';
+import Article, { ArticleModel } from '../model/Article';
 
 const router = express.Router();
 /**
@@ -64,6 +66,26 @@ const router = express.Router();
  *                  type: array
  *                  items:
  *                    $ref: '#/components/schemas/Article'
+ *                totalDocs:
+ *                  type: number
+ *                limit:
+ *                  type: number
+ *                totalPages:
+ *                  type: number
+ *                page:
+ *                  type: number
+ *                pagingCounter:
+ *                  type: number
+ *                hasPrevPage:
+ *                  type: boolean
+ *                hasNextPage:
+ *                  type: boolean
+ *                prevPage:
+ *                  type: number
+ *                  nullable: true
+ *                nextPage:
+ *                  type: number
+ *                  nullable: true
  *      406:
  *        description: 데이터가 올바르지 않음
  *        content:
@@ -88,12 +110,13 @@ router.get(
       });
 
     try {
-      const { code, data } = await RssFeedRepository.pagenateFeed(
+      const { code, data, message } = await RssFeedRepository.pagenateFeed(
         parseInt(page as string)
       );
+      const { docs, ...extra } = data as PaginateResult<ArticleModel>;
       return response
         .status(code)
-        .json({ message: '정상적으로 처리되었습니다.', data: [...data.docs] });
+        .json({ message: message || '', data: docs, ...extra });
     } catch (e) {
       console.log(e);
       return response.status(500).json({ message: '에러가 발생했습니다.' });

--- a/rss_batch_crawler/src/app.ts
+++ b/rss_batch_crawler/src/app.ts
@@ -84,6 +84,8 @@ async function checkRss({
         }),
       filteredItem
     );
+    if(articles.length === 0) return;
+    
     const lastUploadedTime = new Date(
       articles.reduce((latest, cur) => {
         return Math.max(latest, cur.insertDate.getTime());


### PR DESCRIPTION
## 개요 🪧

- /article 응답 데이터 페이지 정보 추가
- 응답시 반환되는 article들이 insertDate을 기준으로 최신순으로 반환됨
 
## 작업 내용 📄

- paginate시 반환되는 정보들을 response body에 추가
- sort옵션에 insertDate를 desc로 추가
- providerName 속성 한글로 변경
- Swagger UI 수정

## 변경 로직 ⚙️

## 스크린샷 📸

![스크린샷 2021-05-09 오후 7 36 14](https://user-images.githubusercontent.com/61958795/117568882-d283ce80-b0fd-11eb-993e-6bb45684877b.png)
