### PR TITLE
article paging response의 likes 속성 추가 

### DIFF
--- a/api_server/src/router/articleRouter.ts
+++ b/api_server/src/router/articleRouter.ts
@@ -119,16 +119,15 @@ router.get('/', async (req: Request, res: Response) => {
     return res.status(500).json({ message: '에러가 발생했습니다.' });
   }
 });
-
 router.get('/comments', async (req: Request, res: Response) => {
   const articleId = req.query.articleId as string;
   if (!articleId)
     return res.status(400).json({ message: 'articleId가 필요합니다.' });
 
   try {
-    const { comments } = await commentService.findCommentsByArticleId(
+    const { comments } = (await commentService.findCommentsByArticleId(
       articleId
-    ) as CommentsModel;
+    )) as CommentsModel;
     console.log(comments);
     if (!comments)
       return res.status(404).json({ message: '존재하지 않는 article입니다.' });

--- a/api_server/src/router/providerRouter.ts
+++ b/api_server/src/router/providerRouter.ts
@@ -129,7 +129,6 @@ router.post('/', async (req: Request, res: Response) => {
   }
 });
 
-// 2. 회원 정보 요청
 router.get('/me', async (req: Request, res: Response) => {
   const providerId = req.query.providerId as string;
   if (!providerId) res.status(406).json({ message: 'providerId가 필요합니다' });

--- a/api_server/src/type/ArticleType.ts
+++ b/api_server/src/type/ArticleType.ts
@@ -1,3 +1,5 @@
+import LikeType from './LikeType';
+
 export default interface ArticleType {
   articleId: string;
   provider: {
@@ -12,4 +14,5 @@ export default interface ArticleType {
   thumbnail: string;
   insertDate: Date;
   keywords: string[];
+  likes?: string[];
 }

--- a/front/src/types/response.ts
+++ b/front/src/types/response.ts
@@ -1,0 +1,42 @@
+export interface ProviderMeResponse {
+  message: string;
+  provider: {
+    email: string;
+    name: string;
+    avatar: string;
+    rssLink: string;
+  };
+}
+type Bookmark = {
+  articleId: string;
+  insertedDate: Date;
+};
+export interface ProviderBookmarkResponse {
+  message: string;
+  bookmarks: Bookmark[];
+}
+
+export interface ProviderRssResponse {
+  message: string;
+}
+
+export interface LikeListResponse {
+  message: string;
+  likes: string[]; // providerId[]
+}
+
+export interface LikeClickResponse {
+  message: string;
+}
+export type Comment = {
+  providerId: string;
+  name: string;
+  avatar: string;
+  content: string;
+  insertedDate: Date;
+  lastUpdatedDate: Date;
+};
+export interface ArticleCommentsResponse {
+  message: string;
+  comments: Comment[];
+}


### PR DESCRIPTION
## 개요 🪧

- 사용자가 좋아요 버튼을 눌렀는지 비교 연산을 하기 위해 likes 를 추가적으로 요청해야하는 이슈가 발생함.
 
## 작업 내용 📄

- articleService에서 likes를 추가적으로 쿼리하여 속성을 추가함

## 변경 로직 ⚙️

## 스크린샷 📸

<img width="730" alt="스크린샷 2021-05-20 오후 3 42 24" src="https://user-images.githubusercontent.com/61958795/118931438-f9ee5d00-b981-11eb-9fe7-c0e4441e972b.png">
