### PR TITLE
무한스크롤 오류 해결

### DIFF
--- a/front/src/hooks/useInfiniteScroll.ts
+++ b/front/src/hooks/useInfiniteScroll.ts
@@ -26,22 +26,16 @@ function useInfiniteScroll(callbackFn: PropTypes) {
     };
   }, [target]);
 
-  const onInfiniteScrollInit = (target: HTMLElement | null) => {
+  const onInfiniteScrollUpdate = (target: HTMLElement | null) => {
     if (target) {
       setTarget(target);
     }
   };
 
-  const onInfiniteScrollUpdate = () => {
-    // console.log("update");
-    return io.current && io.current.observe(target as HTMLElement);
-  };
-
   const onInfiniteScrollDisconnect = () => {
-    // console.log("disconnect");
     return io.current && io.current.disconnect();
   };
-  return [onInfiniteScrollInit, onInfiniteScrollUpdate, onInfiniteScrollDisconnect];
+  return [onInfiniteScrollUpdate, onInfiniteScrollDisconnect];
 }
 
 export default useInfiniteScroll;

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -26,6 +26,7 @@ function Home() {
       setCurrentPage((prev) => prev + 1);
     }
   };
+
   const [
     onInfiniteScrollInit,
     onInfiniteScrollUpdate,
@@ -33,14 +34,14 @@ function Home() {
   ] = useInfiniteScroll(handleObserver);
 
   useEffect(() => {
-    onInfiniteScrollInit(document.querySelector('footer'));
-  }, []);
+    if (0 < articles.length && articles.length < 21) {
+      onInfiniteScrollInit(document.querySelector('footer'));
+    }
+  }, [articles]);
 
   useEffect(() => {
-    // setCurrentPage(INITIAL_PAGE_NUMBER);
     if (currentPage < pages) {
       onInfiniteScrollUpdate(document.querySelector('footer'));
-      // console.log('맨밑', currentPage, articles);
     }
   }, [articles, currentPage]);
 

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -27,23 +27,13 @@ function Home() {
     }
   };
 
-  const [
-    onInfiniteScrollInit,
-    onInfiniteScrollUpdate,
-    onInfiniteScrollDisconnect,
-  ] = useInfiniteScroll(handleObserver);
+  const [onInfiniteScrollUpdate, onInfiniteScrollDisconnect] = useInfiniteScroll(handleObserver);
 
   useEffect(() => {
     if (0 < articles.length && articles.length < 21) {
-      onInfiniteScrollInit(document.querySelector('footer'));
-    }
-  }, [articles]);
-
-  useEffect(() => {
-    if (currentPage < pages) {
       onInfiniteScrollUpdate(document.querySelector('footer'));
     }
-  }, [articles, currentPage]);
+  }, [articles]);
 
   useEffect(() => {
     if (currentPage === pages) {


### PR DESCRIPTION
## 개요 🪧

- 무한스크롤 오류 해결
 
## 작업 내용 📄

- 페이지가 처음 렌더링 될 때 2페이지까지 불러와지는 오류를 해결했습니다.
- useInfiniteScroll에서 불필요한 부분(onInfiniteScrollUpdate)을 없애고, onInfiniteScrollInit의 이름을 onInfininteUpdate로 변경하였습니다.

## 변경 로직 ⚙️

- onInfiniteScrollUpdate를 호출하는 useEffect에 조건문 추가 (처음 렌더링 시 1페이지만 요청하기 위해)

## 스크린샷 📸

- X
