### PR TITLE
[HOTFIX] history 필드 오타 수정

### DIFF
--- a/api_server/src/repository/HistoryRepository.ts
+++ b/api_server/src/repository/HistoryRepository.ts
@@ -10,7 +10,7 @@ class HistoryRepository {
   pushHistory(providerId: string, articleId: string) {
     return this.History.findOneAndUpdate(
       { providerId },
-      { $push: { historys: { articleId, insertedDate: new Date() } } },
+      { $push: { histories: { articleId, insertedDate: new Date() } } },
       { new: true }
     ).exec();
   }


### PR DESCRIPTION
## 개요 🪧

- mongoose histories 필드 오타로 인해 db에 insert가 되지 않는 문제 해결
 
## 작업 내용 📄

## 변경 로직 ⚙️

## 스크린샷 📸

<img width="1064" alt="스크린샷 2021-05-27 오후 11 11 53" src="https://user-images.githubusercontent.com/61958795/119841615-ed996f80-bf40-11eb-86d8-c4f6f59e3cf0.png">
