### PR TITLE
방문한 페이지 등록 요청

### DIFF
--- a/front/src/components/PostCardLayout/PostCard/PostCard.tsx
+++ b/front/src/components/PostCardLayout/PostCard/PostCard.tsx
@@ -69,12 +69,27 @@ function PostCard({ data }: PropTypes) {
     }
   };
 
+  // console.log(data);
+
+  // 방문한 게시글 등록
+  const onClickPost = async () => {
+    if (!data.isVisited) {
+      try {
+        const response = await client.patch(`/history?articleId=${data.articleId}`);
+        console.log(response);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  };
+
   return (
     <CardContainer>
       <CardImage
         href={data.articleUrl}
         target={isNewTab ? '_blank' : '_self'}
         rel={isNewTab ? 'noopener noreferrer' : 'prev'}
+        onClick={onClickPost}
       >
         <div className="card-image">
           <img
@@ -85,7 +100,7 @@ function PostCard({ data }: PropTypes) {
       </CardImage>
       <CardContentWrap>
         <div className="sub-info">{dayjs(data.insertDate).format('MMM DD, YYYY')}</div>
-        <CardContent href={data.articleUrl}>
+        <CardContent href={data.articleUrl} onClick={onClickPost}>
           <h3>{data.title}</h3>
         </CardContent>
       </CardContentWrap>

--- a/front/src/components/PostCardLayout/PostCard/PostCard.tsx
+++ b/front/src/components/PostCardLayout/PostCard/PostCard.tsx
@@ -32,7 +32,7 @@ function PostCard({ data }: PropTypes) {
         }
       }
     }
-  }, []);
+  }, [providerId]);
 
   // 좋아요 요청
   const requestLikes = async (bool: boolean) => {
@@ -69,8 +69,6 @@ function PostCard({ data }: PropTypes) {
     }
   };
 
-  // console.log(data);
-
   // 방문한 게시글 등록
   const onClickPost = async () => {
     if (!data.isVisited) {
@@ -83,14 +81,16 @@ function PostCard({ data }: PropTypes) {
     }
   };
 
+  const cardProps = {
+    href: data.articleUrl,
+    target: isNewTab ? '_blank' : '_self',
+    rel: isNewTab ? 'noopener noreferrer' : '',
+    onClick: onClickPost,
+  };
+
   return (
     <CardContainer>
-      <CardImage
-        href={data.articleUrl}
-        target={isNewTab ? '_blank' : '_self'}
-        rel={isNewTab ? 'noopener noreferrer' : 'prev'}
-        onClick={onClickPost}
-      >
+      <CardImage {...cardProps}>
         <div className="card-image">
           <img
             src="https://media.vlpt.us/images/jjunyjjuny/post/e7f0d557-1fab-4a61-ae8e-b5cb1a911b09/ek7ji4zrimozpp2yzk0a.png?w=640"
@@ -100,7 +100,7 @@ function PostCard({ data }: PropTypes) {
       </CardImage>
       <CardContentWrap>
         <div className="sub-info">{dayjs(data.insertDate).format('MMM DD, YYYY')}</div>
-        <CardContent href={data.articleUrl} onClick={onClickPost}>
+        <CardContent {...cardProps}>
           <h3>{data.title}</h3>
         </CardContent>
       </CardContentWrap>

--- a/front/src/types/article.d.ts
+++ b/front/src/types/article.d.ts
@@ -1,6 +1,8 @@
 export interface IArticle {
   articleId: string;
   articleUrl: string;
+  isBookmarked: boolean;
+  isVisited: boolean;
   insertDate: string;
   keywords: string[];
   likes: {


### PR DESCRIPTION
## 개요 🪧

- 방문한 페이지 등록 요청 (PATCH)
 
## 작업 내용 📄

- isVisited가 false인 article을 클릭했을 때, /history에 articleId를 담은 쿼리문을 보냅니다.
- 현재 탭에서 페이지 이동 후 돌아왔을 때 좋아요 상태가 반영 안되는 현상을 수정했습니다.

## 변경 로직 ⚙️

- X

## 스크린샷 📸
![image](https://user-images.githubusercontent.com/73068489/119930021-9d122880-bfb9-11eb-97b8-e961493782f8.png)
