### PR TITLE
[ADD] 블로그 목록 조회 API 추가

### DIFF
--- a/api_server/src/repository/providerRepository.ts
+++ b/api_server/src/repository/providerRepository.ts
@@ -1,3 +1,4 @@
+import { FilterQuery } from 'mongoose';
 import Provider, { ProviderModel } from '../model/Provider';
 export interface SaveProviderProps {
   providerId: string;
@@ -44,12 +45,14 @@ class providerRepository {
       },
     );
   }
-
-  async findProviderById(providerId: string) {
+  async findByQuery(query: FilterQuery<ProviderModel>) {
+    return this.Provider.find(query, { _id: 0, providerId: 0, lastModifiedTime: 0 });
+  }
+  async findOneByProviderId(providerId: string) {
     return await this.Provider.findOne(
       { providerId },
-      { _id: 0, email: 1, name: 1, avatar: 1, rssLink: 1, likes: 1 },
-    ).exec();
+      { _id: 0, providerId: 0, lastModifiedTime: 0 },
+    );
   }
   async resetLastModifiedTimes() {
     return await this.Provider.updateMany(

--- a/api_server/src/router/providerRouter.ts
+++ b/api_server/src/router/providerRouter.ts
@@ -39,7 +39,7 @@ router.get('/me', async (req: Request, res: Response) => {
   if (!providerId) res.status(406).json({ message: 'providerId가 필요합니다' });
 
   try {
-    const result = await providerService.findProviderById(providerId);
+    const result = await providerService.findOneByProviderId(providerId);
     if (!result) return res.status(404).json({ message: '존재하지 않는 회원입니다.' });
 
     return res.status(200).json({ message: '정상적으로 처리되었습니다.', provider: result });
@@ -47,6 +47,23 @@ router.get('/me', async (req: Request, res: Response) => {
     return res.status(500).json({ message: '서버 오류.' });
   }
 });
+
+// 블로그 목록 요청
+router.get('/blogs', async (req, res) => {
+  try {
+    const result = await providerService.findAllBlogProviders();
+    return res
+      .status(200)
+      .json({
+        message: '정상적으로 처리되었습니다.',
+        blogs: result || [],
+        count: result.length || 0,
+      });
+  } catch (error) {
+    return res.status(500).json({ message: '서버 오류.' });
+  }
+});
+
 router.post('/rss', async (req: Request, res: Response) => {
   const { providerId, rssUrl } = req.body;
   if (!providerId || !rssUrl)

--- a/api_server/src/service/providerService.ts
+++ b/api_server/src/service/providerService.ts
@@ -1,6 +1,4 @@
-import providerRepository, {
-  SaveProviderProps,
-} from '../repository/providerRepository';
+import providerRepository, { SaveProviderProps } from '../repository/providerRepository';
 import bookmarkRepository from '../repository/BookmarkRepository';
 import HistoryRepository from '../repository/HistoryRepository';
 class ProviderService {
@@ -22,8 +20,12 @@ class ProviderService {
     ]);
     return results;
   }
-  async findProviderById(providerId: string) {
-    return await this.providerRepository.findProviderById(providerId);
+
+  async findAllBlogProviders() {
+    return await this.providerRepository.findByQuery({ $nor: [{ rssLink: 'default' }] });
+  }
+  async findOneByProviderId(providerId: string) {
+    return await this.providerRepository.findOneByProviderId(providerId);
   }
   async resetLastModifiedTime() {
     return await this.providerRepository.resetLastModifiedTimes();

--- a/front/src/pages/api/provider/blogs.ts
+++ b/front/src/pages/api/provider/blogs.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { NextApiRequest, NextApiResponse } from 'next-auth/internals/utils';
+
+import { API_SERVER_URL } from '@/config/constants';
+
+/**
+ * 블로그 목록 요청
+ * GET /provider/blogs
+ */
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (req.method == 'GET') {
+      const url = `${API_SERVER_URL}/provider/blogs`;
+      const { data, status } = await axios.get(url);
+      return res.status(status).json(data);
+    }
+  } catch (error) {
+    return res.status(500).json({ error });
+  }
+  return res.status(405).end();
+};

--- a/front/src/types/response.d.ts
+++ b/front/src/types/response.d.ts
@@ -1,13 +1,21 @@
 import { IArticle } from './article';
 
+interface Provider {
+  email: string;
+  name: string;
+  avatar: string;
+  rssLink: string;
+}
+
+export interface BlogsResponse {
+  message: string;
+  blogs: Provider[];
+  count: number;
+}
+
 export interface ProviderMeResponse {
   message: string;
-  provider: {
-    email: string;
-    name: string;
-    avatar: string;
-    rssLink: string;
-  };
+  provider: Provider;
 }
 
 export interface ArticlesResponse {


### PR DESCRIPTION
## 개요 🪧

- 블로그 목록 조회 API 추가
 
## 작업 내용 📄

- provder 라우터, 서비스, 레파지토리에 블로그 목록 조회 메서드 추가  

## 변경 로직 ⚙️
## 사용 방법 📸
```js
/* 요청 메서드 */
client.get('/provider/blogs')

/* 타입 */
interface BlogsResponse {
  message: string; // 성공 메세지
  blogs: Provider[]; // 블로그 목록
  count: number; // 블로그 목록 수
}
```
